### PR TITLE
Fix production css pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev:postcss": "postcss src/_assets/stylesheets/*.css -o src/static/app.compiled.css --watch --verbose",
 		"dev:scripts": "webpack --watch --config webpack.config.js",
 		"dev:11ty": "eleventy --serve --watch",
-		"build:postcss": "NODE_ENV=production postcss src/_assets/stylesheets/app.css -o src/_includes/app.compiled.css",
+		"build:postcss": "NODE_ENV=production postcss src/_assets/stylesheets/app.css -o src/static/app.compiled.css",
 		"build:11ty": "ELEVENTY_ENV=production eleventy",
 		"build:scripts": "NODE_ENV=production webpack -p --config webpack.config.js",
 		"start": "run-p dev:* --print-label",


### PR DESCRIPTION
It seems that the output path for the postcss compiled production css file is not correct. Wasn't copied to the dist folder in my case.
Correcting the path to the same that is used in the debug postcss seems to fix it.